### PR TITLE
Overload flake8 rule for black

### DIFF
--- a/scripts/action-config.cfg
+++ b/scripts/action-config.cfg
@@ -5,6 +5,8 @@
 [flake8]
 # Base flake8 configuration:
 # https://flake8.pycqa.org/en/latest/user/configuration.html
+ignore = D203
+max-line-length = 88
 format = default
 show-source = False
 statistics = False


### PR DESCRIPTION
# I have made things!

Overload flake8 rules getting a consistency to black.
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company is finding wemake-python-styleguide valuable, help us sustain the project by sponsoring it transparently on https://opencollective.com/wemake-python-styleguide. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
